### PR TITLE
:hammer: Fix back-end type4 type not  working 修复默认后端 type 4 更新强度不工作问题

### DIFF
--- a/socket/BackEnd(Node)/websocketNode.js
+++ b/socket/BackEnd(Node)/websocketNode.js
@@ -112,7 +112,10 @@ wss.on('connection', function connection(ws) {
                     }
                     if (clients.has(targetId)) {
                         const client = clients.get(targetId);
-                        const sendData = { type: "msg", clientId, targetId, message }
+                        const sendChannel = data.channel ? data.channel : 1;
+                        const sendStrength = data.strength //增加模式强度改成1
+                        const msg = "strength-" + sendChannel + "+2+" + sendStrength;
+                        const sendData = { type: "msg", clientId, targetId, message:msg }
                         client.send(JSON.stringify(sendData));
                     }
                     break;


### PR DESCRIPTION
默认后端，在根据文档使用 type 4 更新强度不工作问题 ，

“B通道强度变10 : { type : 4,strength: 10,message : 'set channel',channel:2,clientId:xxxx-xxxxxxxxx-xxxxx-xxxxx-xx,targetId:xxxx-xxxxxxxxx-xxxxx-xxxxx-xx }“

修复请求默认后端ws更新强度没进行更新的问题。